### PR TITLE
Allow to use CMake FetchContent without GoogleTest dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,13 @@ include(FetchContent)
 project(erased LANGUAGES CXX)
 
 add_subdirectory(erased)
-add_subdirectory(tests)
-add_subdirectory(benchmarks)
+
+option(ERASED_BUILD_TESTS "Build Erased tests" ON)
+option(ERASED_BUILD_BENCHMARKS "Build Erased benchmarks" ON)
+
+if(ERASED_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()
+if(ERASED_BUILD_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif()


### PR DESCRIPTION
I use option to prevent downloading GoogleTest in project while it is not useful. What do you think?
It could be more sophisticated like [Catch2](https://github.com/catchorg/Catch2/blob/devel/CMakeLists.txt) but it is working.